### PR TITLE
Some backwards compatible extending

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,5 @@
 fixtures:
   repositories:
-    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
   symlinks:
     softwarecollectionsorg: "#{source_dir}"

--- a/Modulefile
+++ b/Modulefile
@@ -1,10 +1,10 @@
 name          'puppet-softwarecollectionsorg'
-version       '0.1.0'
+version       '0.2.0'
 source        'UNKNOWN'
 author        'smerrill'
 license       'Apache License, Version 2.0'
 summary       'Add Software Collections from softwarecollections.org.'
-description   'A quick way to add Software Collections from softwarecollections.org to a RHEL or CentOS system.'
+description   'A quick way to add Software Collections from softwarecollections.org to a Fedora or RHEL/CentOS system.'
 project_page  'https://github.com/smerrill/puppet-softwarecollectionsorg'
 
 dependency 'puppetlabs/stdlib'

--- a/README.markdown
+++ b/README.markdown
@@ -2,8 +2,29 @@
 
 A Puppet module to install software collections from softwarecollections.org.
 
-These collections only currently work on RHEL and CentOS.
+These collections only currently work on Fedora and RHEL/CentOS.
+
+##Usage
+
+To include a SCL repository and its packages:
+
+    softwarecollectionsorg { 'ruby200': }
+
+To disable the SCL repository, but not remove it or related packages
+
+    softwarecollectionsorg { 'ruby200': enabled => 0 }
+
+To remove the repository and related base package (See limitation #2)
+
+    softwarecollectionsorg { 'ruby200': ensure => absent }
+
+To install the scl-utils-build package
+
+    include softwarecollectionsorg::build_package
+
 
 ##Limitations
 
-Software collection from softwarecollections.org are not currently GPG signed.
+* Software collection from softwarecollections.org are not currently GPG signed.
+* This packages instals the base package for a collection, and removes it when set to absent. This does not remove all the packages brought in by the base package.  You can do this by running:
+    yum remove <name of collection>*

--- a/README.markdown
+++ b/README.markdown
@@ -22,6 +22,10 @@ To install the scl-utils-build package
 
     include softwarecollectionsorg::build_package
 
+Remove the scl-utils package
+
+    class { '::softwarecollectionsorg::utils_package': ensure => absent }
+
 
 ##Limitations
 

--- a/manifests/build_package.pp
+++ b/manifests/build_package.pp
@@ -1,0 +1,19 @@
+# == Class: softwarecollectionsorg::build_package
+#
+# A class to make it easy to install Software Collections from
+# https://softwarecollections.org/.
+#
+# === Parameters
+#
+# [*ensure*]
+#   Basic present/absent behavior for the resources contained in this module
+#
+class softwarecollectionsorg::build_package (
+  $ensure = present,
+) {
+
+  package { 'scl-utils-build':
+    ensure  => $ensure,
+  }
+
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,7 +61,6 @@ define softwarecollectionsorg (
     $dist = 'epel'
   }
 
-
   include ::softwarecollectionsorg::util_package
 
   if $scl_url == undef {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,16 +7,27 @@
 #
 # [*title*]
 #   The name of the Software Collection to install.
+# [*ensure*]
+#   Basic present/absent behavior for the resources contained in this module
+# [*enabled*]
+#   Even if present, should the repository be enabled?
 # [*scl_url*]
 #   The URL to the repository for the Software Collection. This can be
 #   automatically calculated based on the name of the Software Collection.
-# [*epel_version*]
-#   The version of EPEL (6 or 7) that this SCL should be used with. This
+# [*os_version*]
+#   The version of Fedora or EL (6 or 7) that this SCL should be used with. This
 #   parameter defaults to the value of the 'operatingsystemmajrelease' fact.
+# [*epel_version*]
+#   DEPRECATED, but takes precedence for backward compatability! The version
+#   of EPEL (6 or 7) that this SCL should be used with. This parameter defaults
+#   to the value of the 'operatingsystemmajrelease' fact.
 #
 define softwarecollectionsorg (
-  $scl_url = undef,
-  $epel_version = $::operatingsystemmajrelease,
+  $ensure       = present,
+  $enabled      = 1,
+  $scl_url      = undef,
+  $epel_version = undef,
+  $os_version   = $::operatingsystemmajrelease,
 ) {
   case $::osfamily {
     'RedHat': {
@@ -30,27 +41,58 @@ define softwarecollectionsorg (
     'x86_64': {
     }
     default: {
-      fail("Software Collections from softwarecollections.org cannot be installed on ${::operatingsystem}.")
+      fail("Software Collections from softwarecollections.org cannot be installed on ${::architecture}.")
     }
   }
 
-  case $::operatingsystemmajrelease {
-    undef: {
-      fail("The release of RHEL/CentOS you are on is unknown to Puppet. Please set the 'epel_version' parameter.")
-    }
+  # change to $os_version when removing epel_version
+  if $os_version == undef and $epel_version == undef {
+    fail("The release of Fedora/RHEL/CentOS you are on is unknown to Puppet. Please set the 'os_version' parameter.")
   }
+  if $epel_version != undef {
+    $dist_version = $epel_version
+  } else {
+    $dist_version = $os_version
+  }
+
+  if $::operatingsystem == 'Fedora' {
+    $dist = downcase($::operatingsystem)
+  } else {
+    $dist = 'epel'
+  }
+
+
+  include ::softwarecollectionsorg::util_package
 
   if $scl_url == undef {
-    $baseurl = "https://www.softwarecollections.org/repos/rhscl/${title}/epel-${epel_version}-x86_64"
+    $baseurl = "https://www.softwarecollections.org/repos/rhscl/${title}/${dist}-${dist_version}-x86_64"
   }
   else {
     $baseurl = $scl_url
   }
 
-  yumrepo { "rhscl-${title}-epel-${epel_version}-x86_64":
-    descr    => "${title} epel-${epel_version}-x86_64",
+  $repo_name = "rhscl-${title}-${dist}-${dist_version}-x86_64"
+  yumrepo { $repo_name:
+    ensure   => $ensure,
+    descr    => $repo_name,
     baseurl  => $baseurl,
-    enabled  => 1,
+    enabled  => $enabled,
     gpgcheck => 0,
+    require  => Class['::softwarecollectionsorg::util_package']
   }
+
+  package { $title:
+    ensure  => $ensure,
+    require => Yumrepo[$repo_name],
+  }
+
+  if $ensure == absent {
+    file { "/etc/yum.repos.d/${repo_name}.repo":
+      ensure => absent,
+    }
+    notify { 'SCL Removal':
+      message => 'Ensuring that this SCL is absent does not necessarily remove all the packages it installed'
+    }
+  }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,7 +72,7 @@ define softwarecollectionsorg (
 
   $repo_name = "rhscl-${title}-${dist}-${dist_version}-x86_64"
   yumrepo { $repo_name:
-    ensure   => $ensure,
+#    ensure   => $ensure,
     descr    => $repo_name,
     baseurl  => $baseurl,
     enabled  => $enabled,

--- a/manifests/util_package.pp
+++ b/manifests/util_package.pp
@@ -1,0 +1,19 @@
+# == Class: softwarecollectionsorg::util_package
+#
+# A class to make it easy to install Software Collections from
+# https://softwarecollections.org/.
+#
+# === Parameters
+#
+# [*ensure*]
+#   Basic present/absent behavior for the resources contained in this module
+#
+class softwarecollectionsorg::util_package (
+  $ensure = present,
+) {
+
+  package { 'scl-utils':
+    ensure  => $ensure,
+  }
+
+}


### PR DESCRIPTION
This should be completely backwards compatible, but the rake spec wouldnt run before i made the changes so :frowning: 
- Addresses #1 in an always there when you need it kinda way
- Added support for -builds package to be brought in when needed
- Support both EL and Fedora (some SCLs dont, but there is no way for us to infer that)
- Support for disabling the repo, without uninstalling it
- Support for removing the majority of what this installs (unfortunately you cant wildcard so non-umbrella packages stay on the system. Added a notification about this. Could do an exec, but ewww)
- Bumped version so it can be tagged.
- Changed fixture to use https since some corp firewalls block git over non-https, and even block ssh.
